### PR TITLE
add_column fails in active record migration with undefined method `array' for nil:NilClass 

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -165,7 +165,7 @@ module ActiveRecord
       NATIVE_DATABASE_TYPES.merge!(EXTENDED_TYPES)
 
       def add_column_options!(sql, options)
-        if options[:column].array
+        if options[:array] || options[:column].try(:array)
           sql << '[]'
         end
         super

--- a/spec/migrations/active_record_migration_spec.rb
+++ b/spec/migrations/active_record_migration_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'activerecord migrations' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  it 'creates non-postgres_ext columns' do
+
+    lambda do
+      DoMigration.new.up
+    end.should_not raise_exception
+
+    columns = connection.columns(:generic_data_types)
+    col_1 = columns.detect { |c| c.name == 'col_1'}
+    col_2 = columns.detect { |c| c.name == 'col_2'}
+    col_3 = columns.detect { |c| c.name == 'col_3'}
+    col_4 = columns.detect { |c| c.name == 'col_4'}
+
+
+    col_1.sql_type.should eq 'integer'
+    col_2.sql_type.should eq 'character varying(255)'
+    col_3.sql_type.should eq 'timestamp without time zone'
+    col_4.sql_type.should eq 'text'
+  end
+end
+
+
+class DoMigration < ActiveRecord::Migration
+  def up
+    create_table :generic_data_types do |t|
+      t.integer :col_1
+      t.string :col_2
+      t.datetime :col_3
+    end
+    add_column :generic_data_types, :col_4, :text
+  end
+end
+


### PR DESCRIPTION
undefined method `array' for nil:NilClass
/Users/gill/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/postgres_ext-0.0.5/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb:168:in`add_column_options!'
/Users/gill/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/activerecord-3.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:1020:in `add_column'

with a migration that looks like:

add_column :table_blah, :name, :string

There's a spec to show that breaking (if you remove the patch to postgres_ext/active_record/connection_adapters/postgres_adapter.rb) and the adapter has been patched to hopefully fix the issue.

Someone please look over this, I am not familiar with this code - the tests all pass, but i don't want to be doing something stupid.
