### PR TITLE
add support for UUID primary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ create_table :testing do |t|
   # or
   t.column :uuid_column, :uuid
 end
+
+# or to create a table with a UUID primary key
+create_table :testing, :id => false do |t|
+  t.uuid :id, :primary_key => true
+end
 ```
 
 ### Arrays

--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -113,6 +113,7 @@ module ActiveRecord
       EXTENDED_TYPES = {:inet => {:name => 'inet'}, :cidr => {:name => 'cidr'}, :macaddr => {:name => 'macaddr'}, :uuid => {:name => 'uuid'}}
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
         attr_accessor :array
+        attr_accessor :primary_key
       end
 
       class TableDefinition
@@ -132,6 +133,7 @@ module ActiveRecord
 
           column = self[name]
           column.array     = options[:array]
+          column.primary_key = options[:primary_key]
 
           self
         end
@@ -175,6 +177,8 @@ module ActiveRecord
       def add_column_options!(sql, options)
         if options[:array] || options[:column].try(:array)
           sql << '[]'
+        elsif options[:primary_key] || options[:column].try(:primary_key)
+          sql << ' PRIMARY KEY'
         end
         super
       end


### PR DESCRIPTION
ActiveRecord essentially assumes primary keys in PostgreSQL are sequences. As a result, there is no way to use the migrations DSL to create UUID primary key or add a primary key index to an existing UUID column.

I have been using `execute` with raw SQL to create tables with UUID primary keys, but support in the gem would be amazing.
