### PR TITLE
Attempted fix for array of strings with special characters

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -303,7 +303,19 @@ module ActiveRecord
       end
 
       def array_to_string(value, column)
-        "{#{value.map{|val| type_cast(val, column, true)}.join(',')}}"
+        "{#{value.map { |val| item_to_string(val, column) }.join(',')}}"
+      end
+      
+      private
+      
+      def item_to_string(value, column)
+        if value.nil?
+          'NULL'
+        elsif value.is_a?String
+          '"' + type_cast(value, column, true).gsub('"', '\\"') + '"'
+        else
+          type_cast(value, column, true)
+        end
       end
     end
   end

--- a/spec/columns/array_spec.rb
+++ b/spec/columns/array_spec.rb
@@ -18,8 +18,20 @@ describe 'Array column' do
           string_array_column.type_cast('{"has \" quote",another value}').should eq ['has " quote', 'another value']
         end
 
-        it 'converts the PostgreSQL value containgin commas to an array' do
+        it 'converts the PostgreSQL value containing commas to an array' do
           string_array_column.type_cast('{"has , comma",another value,"more, commas"}').should eq ['has , comma', 'another value', 'more, commas']
+        end
+
+        it 'converts strings containing , to the proper value' do
+          adapter.type_cast(['c,'], string_array_column).should eq '{"c,"}'
+        end
+        
+        it "handles strings with double quotes" do
+          adapter.type_cast(['a"b'], string_array_column).should eq '{"a\\"b"}'
+        end
+
+        it 'converts arrays of strings containing nil to the proper value' do
+          adapter.type_cast(['one', nil, 'two'], string_array_column).should eq '{"one",NULL,"two"}'
         end
       end
     end


### PR DESCRIPTION
This escapes PostgreSQL strings with double quotes in the SQL in all cases, while leaving other types unquoted.  A double quote itself is stored as \", and nil is encoded as NULL directly, without quotes.

All previous tests passed, although few of them seem to actually exercise PostgreSQL itself, so I am not sure how reliable some of them are.  A few new tests were added as well.
