### PR TITLE
UTF-8 strings in string arrays are not returned as UTF-8 encoded strings

### DIFF
--- a/spec/columns/array_spec.rb
+++ b/spec/columns/array_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe 'Array column' do
@@ -13,6 +15,12 @@ describe 'Array column' do
         end
       end
 
+      context 'utf8' do
+        it "handles incoming UTF8 as UTF8" do
+          string_array_column.type_cast('{"Аркалио"}').should eq ['Аркалио']
+        end
+      end
+
       context 'corner cases, strings with commas and quotations' do
         it 'converts the PostgreSQL value containing escaped " to an array' do
           string_array_column.type_cast('{"has \" quote",another value}').should eq ['has " quote', 'another value']
@@ -25,7 +33,7 @@ describe 'Array column' do
         it 'converts strings containing , to the proper value' do
           adapter.type_cast(['c,'], string_array_column).should eq '{"c,"}'
         end
-        
+
         it "handles strings with double quotes" do
           adapter.type_cast(['a"b'], string_array_column).should eq '{"a\\"b"}'
         end


### PR DESCRIPTION
This has some flaws:
1. It will blindly force UTF-8 encoding on all strings.  This could break things if people are using strings to hold binary data, which they should not be doing.
2. It assumes the only database encoding in use is UTF-8, and does not respect any encodings configured.

I don't (yet) know how to fix (2) but will look into it.  I sort of hoped I could just steal the options[:encoding] value...

In any case, this now makes arrays UTF-8 clean from what I can tell.
