### PR TITLE
String encoding fix, part 2

### DIFF
--- a/lib/postgres_ext/arel/visitors/to_sql.rb
+++ b/lib/postgres_ext/arel/visitors/to_sql.rb
@@ -22,11 +22,7 @@ module Arel
 
       def change_string value
         return value unless value.is_a?(String)
-        if value.match /"|,|\{/
-          value.gsub(/"/, "\"").gsub(/'/,'"')
-        else
-          value.gsub(/'/,'')
-        end
+        value.gsub(/^\'/, '"').gsub(/\'$/, '"')
       end
     end
   end

--- a/spec/arel/array_spec.rb
+++ b/spec/arel/array_spec.rb
@@ -23,7 +23,7 @@ describe 'Array Column Predicates' do
     it 'converts Arel array_overlap statment' do
       arel_table = ArelArray.arel_table
 
-      arel_table.where(arel_table[:tags].array_overlap(['tag','tag 2'])).to_sql.should match /&& '\{tag,tag 2\}'/
+      arel_table.where(arel_table[:tags].array_overlap(['tag','tag 2'])).to_sql.should match /&& '\{"tag","tag 2"\}'/
     end
 
     it 'converts Arel array_overlap statment' do

--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -87,6 +87,105 @@ describe 'Models with array columns' do
         end
       end
     end
+
+    describe 'strings contain special characters' do
+      context '#save' do
+        it 'contains: \'' do
+          data = ['some\'thing']
+          u = User.create
+          u.nick_names = data
+          u.save!
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: {' do
+          data = ['some{thing']
+          u = User.create
+          u.nick_names = data
+          u.save!
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: }' do
+          data = ['some}thing']
+          u = User.create
+          u.nick_names = data
+          u.save!
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: backslash' do
+          data = ['some\\thing']
+          u = User.create
+          u.nick_names = data
+          u.save!
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: "' do
+          data = ['some"thing']
+          u = User.create
+          u.nick_names = data
+          u.save!
+          u.reload
+          u.nick_names.should eq data
+        end
+      end
+
+      context '#create' do
+        it 'contains: \'' do
+          data = ['some\'thing']
+          u = User.create(:nick_names => data)
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: {' do
+          data = ['some{thing']
+          u = User.create(:nick_names => data)
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: }' do
+          data = ['some}thing']
+          u = User.create(:nick_names => data)
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: backslash' do
+          data = ['some\\thing']
+          u = User.create(:nick_names => data)
+          u.reload
+          u.nick_names.should eq data
+        end
+
+        it 'contains: "' do
+          data = ['some"thing']
+          u = User.create(:nick_names => data)
+          u.reload
+          u.nick_names.should eq data
+        end
+      end
+    end
+
+    describe 'array_overlap' do
+      it "works" do
+        arel = User.arel_table
+        User.create(:nick_names => ['this'])
+        x = User.create
+        x.nick_names = ["s'o{m}e", 'thing']
+        x.save
+        u = User.where(arel[:nick_names].array_overlap(["s'o{m}e"]))
+        u.first.should_not be_nil
+        u.first.nick_names.should eq ["s'o{m}e", 'thing']
+      end
+    end
   end
 
   context 'default values' do


### PR DESCRIPTION
PostgreSQL requires a very special string encoding in the literal array syntax.  This patch fixes that in the "update" case, but does not fix the problem with array_overlap() generating bad SQL.

I've run out of time today to work on this, but I've given Dan access to my fork, so if he can figure out why this:

```
    u = User.where(arel[:nick_names].array_overlap(["s'o{m}e"]))
```

generates this SQL:

```
   : SELECT  "users".* FROM "users"  WHERE ("users"."nick_names" && '{"s""o{m}e"}') LIMIT 1
```

(and ideally why I need to gsub '\' to '\\\\' -- yes, that's eight slashes -- I'd be thrilled)
