### PR TITLE
Fix number arrays + test

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -331,11 +331,12 @@ module ActiveRecord
       end
 
       def item_to_string(value, column, encode_single_quotes = false)
-        if value.nil?
-          'NULL'
-        elsif value.is_a? String
-          casted_value = type_cast(value, column, true)
-          casted_value = casted_value.dup unless [Fixnum, Float].include?(casted_value.class)
+        return 'NULL' if value.nil?
+
+        casted_value = type_cast(value, column, true)
+
+        if casted_value.is_a? String
+          casted_value = casted_value.dup
           # Encode backslashes.  One backslash becomes 4 in the resulting SQL.
           # (why 4, and not 2?  Trial and error shows 4 works, 2 fails to parse.)
           casted_value.gsub!('\\', '\\\\\\\\')
@@ -348,9 +349,10 @@ module ActiveRecord
           if encode_single_quotes
             casted_value.gsub!("'", "''")
           end
+
           "\"#{casted_value}\""
         else
-          type_cast(value, column, true)
+          casted_value
         end
       end
     end

--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -41,6 +41,18 @@ describe 'Models with array columns' do
           u.reload
           u.nick_names.should eq ['some', 'things']
         end
+
+        it 'creates a user with an int array of some values' do
+          u = User.create(:favorite_numbers => [2,3,5])
+          u.reload
+          u.favorite_numbers.should eq [2,3,5]
+        end
+
+        it 'creates a user with an int array of string values' do
+          u = User.create(:favorite_numbers => ['2','3','5'])
+          u.reload
+          u.favorite_numbers.should eq [2,3,5]
+        end
       end
     end
 


### PR DESCRIPTION
Number arrays fixed again and test provided.

Old fix (#87f79754fa20cfd71100be157ee4473bc2583ca1) was not successful as it called gsub! and other string-related methods on numbers.

So, new approach:
- cast value first
- then, if it's string apply string-related transformations
