### PR TITLE
add support to schema.rb to export and import extensions (think hbase, postgis)

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -209,6 +209,10 @@ module ActiveRecord
         execute "CREATE #{unique} INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}#{index_type}(#{index_columns})#{index_options}"
       end
 
+      def add_extension(extension_name, options={})
+        execute "CREATE extension if not exists \"#{extension_name}\""
+      end
+
       def change_table(table_name, options = {})
         if supports_bulk_alter? && options[:bulk]
           recorder = ActiveRecord::Migration::CommandRecorder.new(self)
@@ -318,6 +322,10 @@ module ActiveRecord
           end
           #/changed
         end.compact
+      end
+
+      def extensions
+        select_rows('select extname from pg_extension', 'extensions').map { |row| row[0] }.delete_if {|name| name == 'plpgsql'}
       end
 
       private

--- a/lib/postgres_ext/active_record/schema_dumper.rb
+++ b/lib/postgres_ext/active_record/schema_dumper.rb
@@ -7,7 +7,26 @@ module ActiveRecord
       VALID_COLUMN_SPEC_KEYS
     end
 
+    def dump(stream)
+      header(stream)
+      # added
+      extensions(stream)
+      # /added
+      tables(stream)
+      trailer(stream)
+      stream
+    end
+
     private
+
+    def extensions(stream)
+      exts=@connection.extensions
+
+      unless exts.empty?
+        stream.puts exts.map { |name| "  add_extension \"#{name}\""}.join("\n") + "\n\n"
+      end
+    end
+
     def table(table, stream)
       columns = @connection.columns(table)
       begin

--- a/spec/schema_dumper/extension_spec.rb
+++ b/spec/schema_dumper/extension_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'extension schema dump' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  it 'correctly creates and exports database extensions' do
+    stream = StringIO.new
+    connection.add_extension 'hstore'
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+    output = stream.string
+
+    output.should match /add_extension "hstore"/
+  end
+end


### PR DESCRIPTION
Hi Dan/crew,

I use extensions in my database.
schema dumper does not add these extensions to the schema.rb file, so they don't get into the test database.
My tests fail.

I modified the dumper / loader to support "add_extension" method which adds a native database extension. It skips the pgpsql extension since that is in the default database template by default.

If you want me to add more options, please let me know.

Thanks,
Keenan
