### PR TITLE
remove support for integer_array and string_array columns

### DIFF
--- a/spec/dummy/db/migrate/20120501163758_create_people.rb
+++ b/spec/dummy/db/migrate/20120501163758_create_people.rb
@@ -3,9 +3,9 @@ class CreatePeople < ActiveRecord::Migration
     create_table :people do |t|
       t.inet :ip
       t.cidr :subnet, :subnet2
-      t.integer_array :arrayzerd
-      t.inet_array :inet_arrayzerd
-      t.string_array :str_arrayzerd, :limit => 5
+      t.integer :arrayzerd, :array => true
+      t.inet :inet_arrayzerd, :array => true
+      t.string :str_arrayzerd, :array => true, :limit => 5
       t.string :test
 
       t.timestamps

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -13,20 +13,18 @@
 
 ActiveRecord::Schema.define(:version => 20120501163758) do
 
-  create_table "people", :force => true do |t|
-    t.inet          "ip"
-    t.cidr          "subnet"
-    t.cidr          "subnet2"
-    t.integer_array "arrayzerd"
-    t.inet_array    "inet_arrayzerd"
-    t.string_array  "str_arrayzerd",  :limit => 5
-    t.string        "test"
-    t.datetime      "created_at",                  :null => false
-    t.datetime      "updated_at",                  :null => false
-  end
+  add_extension "hstore"
 
-  create_table "test", :id => false, :force => true do |t|
-    t.string "test_a"
+  create_table "people", :force => true do |t|
+    t.inet     "ip"
+    t.cidr     "subnet"
+    t.cidr     "subnet2"
+    t.integer  "arrayzerd",                                   :array => true
+    t.inet     "inet_arrayzerd",                              :array => true
+    t.string   "str_arrayzerd",  :limit => 5,                 :array => true
+    t.string   "test"
+    t.datetime "created_at",                  :null => false
+    t.datetime "updated_at",                  :null => false
   end
 
 end


### PR DESCRIPTION
Hi,

The migrations are failing for me when they are of the type `"#{type}_array"` - the type `:array => true` work for me.

Not making a statement over what type is preferred, just putting this in to fix the build.
Grepping for `_array` returned nothing, so I assumed you removed the code, but since it is meta, it could have squeeked in there some other way.

Hope all is well,
Keenan

not working:

``` ruby
create_table :abc do
  string_array :col1
end
```

working:

``` ruby
create_table :abc do
  string :col1, :array => true
end
```
