### PR TITLE
Schema dumping for indexes without an index_opclass

### DIFF
--- a/lib/postgres_ext/active_record/schema_dumper.rb
+++ b/lib/postgres_ext/active_record/schema_dumper.rb
@@ -119,7 +119,7 @@ module ActiveRecord
           # changed from rails 2.3
           statement_parts << (':where => ' + index.where.inspect) if index.where
           statement_parts << (':index_type => ' + index.index_type.inspect) if index.index_type
-          statement_parts << (':index_opclass => ' + index.index_opclass.inspect) if index.index_opclass
+          statement_parts << (':index_opclass => ' + index.index_opclass.inspect) if index.index_opclass.present?
           # /changed
 
           '  ' + statement_parts.join(', ')

--- a/spec/schema_dumper/index_spec.rb
+++ b/spec/schema_dumper/index_spec.rb
@@ -22,6 +22,7 @@ describe 'Index schema dumper' do
 
     output.should match /:index_type => :gin/
     output.should_not match /:index_type => :btree/
+    output.should_not match /:index_opclass =>/
   end
 
   it 'handles index where clauses' do


### PR DESCRIPTION
Running Rails 3.2.9

When you dump the schema for a GIN index it outputs a blank `index_opclass` argument like so:

``` ruby
add_index "services", ["weighted_search"], :name => "services_weighted_search_idx", :index_type => :gin, :index_opclass => []
```

Trying to load the schema results in this error:

```
PG::Error: ERROR:  syntax error at or near "]"
LINE 1: ...d_search_idx" ON "services" USING gin ("weighted_search" [])
                                                                     ^
: CREATE  INDEX "services_weighted_search_idx" ON "services" USING gin ("weighted_search" [])
```

A fix is attached with tests. Let me know if there's any issues, cheers.
