### PR TITLE
Force correct character encoding on :text columns.

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -56,7 +56,7 @@ module ActiveRecord
           value
         else
           string_array = parse_pg_array value
-          if type == :string
+          if type == :string || type == :text
             force_character_encoding(string_array)
           else
             type_cast_array(string_array)


### PR DESCRIPTION
Hi,

I found a bug where if you've got a column that's a text[], then it doesn't get set to the right character encoding, whereas other string array columns like character varying(255)[] do get set to the right encoding. Here's code that fixes it. I'm not sure if the duplication introduced in array_spec.rb between the 'string array' and 'text array' contexts is ok, and if not how to improve it, as I'm pretty new to rspec and let!. I believe I followed all the contribution guidelines at https://github.com/patientslikeme/postgres_ext/blob/master/CONTRIBUTING.md

Fixes a bug where a text[] column will result in an array of strings
encoded as ASCII-8BIT, regardless of the database's encoding.
