### PR TITLE
Add support for the citext data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ create_table :testing do |t|
 end
 ```
 
+### CITEXT
+
+```ruby
+create_table :testing do |t|
+  t.citext :citext_column
+  # or
+  t.citext :citext_column_1, :citext_column_2
+  # or
+  t.column :citext_column, :citext
+end
+```
+
 ### Arrays
 Arrays are created from any ActiveRecord supported datatype (including
 ones added by postgre\_ext), and respect length constraints

--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -108,6 +108,8 @@ module ActiveRecord
         case field_type
         when 'uuid'
           :uuid
+        when 'citext'
+          :citext
         when 'inet'
           :inet
         when 'cidr'
@@ -125,7 +127,7 @@ module ActiveRecord
     class PostgreSQLAdapter
       class UnsupportedFeature < Exception; end
 
-      EXTENDED_TYPES = {:inet => {:name => 'inet'}, :cidr => {:name => 'cidr'}, :macaddr => {:name => 'macaddr'}, :uuid => {:name => 'uuid'}}
+      EXTENDED_TYPES = {:inet => {:name => 'inet'}, :cidr => {:name => 'cidr'}, :macaddr => {:name => 'macaddr'}, :uuid => {:name => 'uuid'}, :citext => {:citext => 'citext'}}
 
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
         attr_accessor :array

--- a/spec/migrations/citext_spec.rb
+++ b/spec/migrations/citext_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'CITEXT migrations' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  before(:all) { ActiveRecord::Base.connection.add_extension('citext') if ActiveRecord::Base.connection.supports_extensions? }
+  after { connection.drop_table :data_types }
+  it 'creates an citext column' do
+    lambda do
+      connection.create_table :data_types do |t|
+        t.citext :citext_1
+        t.citext :citext_2, :citext_3
+        t.column :citext_4, :citext
+      end
+    end.should_not raise_exception
+
+    columns = connection.columns(:data_types)
+    citext_1 = columns.detect { |c| c.name == 'citext_1'}
+    citext_2 = columns.detect { |c| c.name == 'citext_2'}
+    citext_3 = columns.detect { |c| c.name == 'citext_3'}
+    citext_4 = columns.detect { |c| c.name == 'citext_4'}
+
+    citext_1.sql_type.should eq 'citext'
+    citext_2.sql_type.should eq 'citext'
+    citext_3.sql_type.should eq 'citext'
+    citext_4.sql_type.should eq 'citext'
+  end
+end

--- a/spec/schema_dumper/citext_spec.rb
+++ b/spec/schema_dumper/citext_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'CITEXT schema dump' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  after { connection.drop_table :testings }
+  it 'correctly generates citext column statements' do
+    stream = StringIO.new
+    connection.create_table :testings do |t|
+      t.citext :citext_column
+    end
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+    output = stream.string
+
+    output.should match /t\.citext/
+  end
+end


### PR DESCRIPTION
The citext module provides a case-insensitive character string type, citext.
Essentially, it internally calls lower when comparing values.
Otherwise, it behaves almost exactly like text.
