### PR TITLE
Check if connection responds to #supports_extensions?

### DIFF
--- a/lib/postgres_ext/active_record/schema_dumper.rb
+++ b/lib/postgres_ext/active_record/schema_dumper.rb
@@ -10,7 +10,8 @@ module ActiveRecord
     def dump(stream)
       header(stream)
       # added
-      extensions(stream) if @connection.supports_extensions?
+      extensions(stream) if @connection.respond_to?(:supports_extensions?) && 
+                            @connection.supports_extensions?
       # /added
       tables(stream)
       trailer(stream)


### PR DESCRIPTION
Just added a check if `@connection` responds to `supports_extensions?` before calling it. This prevents errors if you have `postgres_ext` in your `Gemfile` but you're still using another database (e.g. SQLite3 in our case).
