### PR TITLE
Replaced .symbolize with .to_sym in arel nodes.

### DIFF
--- a/lib/postgres_ext/arel/nodes/contained_within.rb
+++ b/lib/postgres_ext/arel/nodes/contained_within.rb
@@ -6,7 +6,7 @@ module Arel
     end
 
     class ContainedWithinEquals < Arel::Nodes::Binary
-      def operator; '<<='.symbolize end
+      def operator; '<<='.to_sym end
     end
 
     class Contains < Arel::Nodes::Binary
@@ -14,7 +14,7 @@ module Arel
     end
 
     class ContainsEquals < Arel::Nodes::Binary
-      def operator; '>>='.symbolize end
+      def operator; '>>='.to_sym end
     end
   end
 end

--- a/spec/arel/inet_spec.rb
+++ b/spec/arel/inet_spec.rb
@@ -17,6 +17,21 @@ describe 'INET related AREL functions' do
     Object.send(:remove_const, :IpAddress)
   end
 
+  describe "arel node operators",:wip => true do
+    it "ContainedWithin" do
+      Arel::Nodes::ContainedWithin.new(nil,nil).operator.should == :<<
+    end
+    it "ContainedWithinEquals" do
+      Arel::Nodes::ContainedWithinEquals.new(nil,nil).operator.should == '<<='.to_sym
+    end
+    it "ContainedWithinEquals" do
+      Arel::Nodes::Contains.new(nil,nil).operator.should == :>>
+    end
+    it "ContainedWithinEquals" do
+      Arel::Nodes::ContainsEquals.new(nil,nil).operator.should == '>>='.to_sym
+    end
+  end
+
   describe 'quoting IPAddr in sql statement' do
     it 'properly converts IPAddr to quoted strings when passed as an argument to a where clause' do
       IpAddress.where(:address => IPAddr.new('127.0.0.1')).to_sql.should include("'127.0.0.1/32'")


### PR DESCRIPTION
Without this patch the arel node classes ContainedWithinEquals and
ContainsEquals used .symbolize instead of .to_sym to crate the
operators. This causes a NoMethodError with: undefined method
`symbolize' for "<<=":String.
This patch addresses this issue by using to_sym instead of
symbolize.
