### PR TITLE
ISN Data Types

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -119,6 +119,8 @@ module ActiveRecord
           :cidr
         when 'macaddr'
           :macaddr
+        when 'ean13'
+          :ean13
         else
           simplified_type_without_extended_types field_type
         end
@@ -131,7 +133,7 @@ module ActiveRecord
       class UnsupportedFeature < Exception; end
 
       EXTENDED_TYPES = { :inet => {:name => 'inet'}, :cidr => {:name => 'cidr'}, :macaddr => {:name => 'macaddr'},
-                         :uuid => {:name => 'uuid'}, :citext => {:name => 'citext'} }
+                         :uuid => {:name => 'uuid'}, :citext => {:name => 'citext'}, :ean13 => {:name => 'ean13'} }
 
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
         attr_accessor :array

--- a/spec/migrations/ean13_spec.rb
+++ b/spec/migrations/ean13_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'ean13 migrations' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  before(:all) { ActiveRecord::Base.connection.add_extension('isn') if ActiveRecord::Base.connection.supports_extensions? }
+  after { connection.drop_table :data_types }
+  it 'creates an ean13 column' do
+    lambda do
+      connection.create_table :data_types do |t|
+        t.ean13 :ean13_1
+        t.ean13 :ean13_2, :ean13_3
+        t.column :ean13_4, :ean13
+      end
+    end.should_not raise_exception
+
+    columns = connection.columns(:data_types)
+    ean13_1 = columns.detect { |c| c.name == 'ean13_1'}
+    ean13_2 = columns.detect { |c| c.name == 'ean13_2'}
+    ean13_3 = columns.detect { |c| c.name == 'ean13_3'}
+    ean13_4 = columns.detect { |c| c.name == 'ean13_4'}
+
+    ean13_1.sql_type.should eq 'ean13'
+    ean13_2.sql_type.should eq 'ean13'
+    ean13_3.sql_type.should eq 'ean13'
+    ean13_4.sql_type.should eq 'ean13'
+  end
+end

--- a/spec/models/ean13_spec.rb
+++ b/spec/models/ean13_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'Models with ean13 columns' do
+  let!(:adapter) { ActiveRecord::Base.connection }
+
+  context 'no default value, ean' do
+    before do
+      adapter.create_table :books, :force => true do |t|
+        t.ean13 :ean
+      end
+
+      class Book < ActiveRecord::Base
+        attr_accessible :ean
+      end
+    end
+
+    after do
+      adapter.drop_table :books
+      Object.send(:remove_const, :Book)
+    end
+
+    context 'no default value, ean' do
+      describe '#create' do
+        it 'create a book when there is no ean assignment' do
+          book = Book.create()
+          book.reload
+          book.ean.should eq nil
+        end
+
+        it 'creates a book with an ean string' do
+          book = Book.create(:ean => '9780312174910')
+          book.reload
+          book.ean.should eq '978-0-312-17491-0'
+        end
+      end
+
+      describe 'ean assignment' do
+        it 'updates a book with an ean string' do
+          book = Book.create(:ean => '9783037781265')
+          book.ean = '9780312174910'
+          book.save
+
+          book.reload
+          book.ean.should eq '978-0-312-17491-0'
+        end
+      end
+
+      describe 'find_by_ean' do
+        let!(:ean) { Book.create(:ean => '9783037781265') }
+
+        it 'finds book using string value' do
+          Book.find_by_ean('9783037781265').should eq ean
+        end
+      end
+    end
+  end
+end

--- a/spec/schema_dumper/ean13_spec.rb
+++ b/spec/schema_dumper/ean13_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'ean13 schema dump' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  after { connection.drop_table :testings }
+  it 'correctly generates ean13 column statements' do
+    stream = StringIO.new
+    connection.create_table :testings do |t|
+      t.ean13 :ean13_column
+    end
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
+    output = stream.string
+
+    output.should match /t\.ean13/
+  end
+end


### PR DESCRIPTION
I've been meaning to add AR/Rails support for a subset of PG contrib's [ISN data types](http://www.postgresql.org/docs/9.2/static/isn.html). Specifically, I'd like to add support for the common UPC, ISBN10, and EAN13 types. 

Is there any interest? If so, are there any objections to only providing partial compatibility with the module?
