### PR TITLE
Fixed compatibility with Squeel

### DIFF
--- a/lib/postgres_ext/active_record/relation/query_methods.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods.rb
@@ -71,11 +71,11 @@ module ActiveRecord
       end
     end
 
-    def where_with_chaining(opts = :chaining, *rest)
-      if opts == :chaining
+    def where_with_chaining(*opts, &block)
+      if opts.empty? && !block_given?
         WhereChain.new(self)
       else
-        where_without_chaining(opts, *rest)
+        where_without_chaining(*opts, &block)
       end
     end
 


### PR DESCRIPTION
Rails version: 3.2.12

This patch fixes work with Squeel.

Root of the problems that Squeel also use where without arguments, so where doesn't use passed block but returns `WhereChain`.

Minimal example that exposes problem:

``` ruby
  User.where{ id > 3 }.uniq
```
