### PR TITLE
Extra stuff on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+language: ruby
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - jruby-18mode
   - jruby-19mode
+  - 2.0.0
 
 before_script:
   - psql -c 'create database postgres_ext_test;' -U postgres
@@ -16,3 +18,18 @@ notifications:
   campfire:
     rooms:
       - secure: "yVESPleawl+fzvnzXw/W7rULyCjMEq3gPc3cEqcqM2SBBtEIDNXto2zoTAoR\nC5yqhijr+UtmVMsI7CxVK3XvfkmCJZN9P4DP0uas8XYx5DsSabCdPN0h3pka\nbaDCMCInU5QF4WswL2iuyLsOJeKDRwxh09adsHi1HpMgf0nTKPA="
+
+env:
+  - "RAILS_VERSION=3.2"
+  - "RAILS_VERSION=master"
+
+matrix:
+  allow_failures:
+    - env: "RAILS_VERSION=master"
+  exclude:
+    - rvm: 1.8.7
+      env: "RAILS_VERSION=master"
+    - rvm: 1.9.2
+      env: "RAILS_VERSION=master"
+    - rvm: jruby-18mode
+      env: "RAILS_VERSION=master"

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,14 @@ unless ENV['CI']
   end
 end
 gem 'fivemat'
+
+version = ENV["RAILS_VERSION"] || "3.2"
+
+rails = case version
+when "master"
+  {:github => "rails/rails"}
+else
+  "~> #{version}.0"
+end
+
+gem "rails", rails

--- a/postgres_ext.gemspec
+++ b/postgres_ext.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PostgresExt::VERSION
 
-  gem.add_dependency 'activerecord', '~> 3.2.0'
+  gem.add_dependency 'activerecord', '>= 3.2.0'
   gem.add_dependency 'pg_array_parser', '~> 0.0.8'
 
   gem.add_development_dependency 'rails', '~> 3.2.0'


### PR DESCRIPTION
This adds Ruby 2.0 and Rails master, and allows failures on Rails
master.

It also excludes builds on the right Rubies that don't support certain
Rails, like 1.8.7 and master.

I added this because someone on HN [says this gem is blocking them from upgrading to Rails 4](https://news.ycombinator.com/item?id=5641560), and at least this will allow you to track rails 4 compatibility, and hopefully add support sometime soon to the release. I barely know anything about this gem, but I could lend a bit of a hand if that interests you...
