### PR TITLE
Add support for SQL_ASCII encoding for Arrays

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -203,6 +203,8 @@ module ActiveRecord
         @database_encoding ||= case ActiveRecord::Base.connection.encoding
                                when 'UTF8'
                                  'UTF-8'
+                               when 'SQL_ASCII'
+                                 'ASCII'
                                else
                                  ActiveRecord::Base.connection.encoding
                                end


### PR DESCRIPTION
In some cases (mostly local development databases), a PostgreSQL database might be accidentally in the SQL_ASCII encoding instead of UTF8.

Right now this fails with postgres_ext if you are loading an array from the database, since there is no encoding called "SQL_ASCII" in Ruby, so force_encoding fails.

This is a really simple fix and just adds a "SQL_ASCII" => "ASCII" mapping, which fixes the error.

I did not provide a test, since the existing code does not have a test, and the mapping already exists for "UTF8" => "UTF-8".
