### PR TITLE
Allow conversion of string/text columns to array

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ unless ENV['CI']
   end
 end
 gem 'fivemat'
+
+group :test, :development do
+  gem 'debugger'
+end

--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -485,7 +485,11 @@ module ActiveRecord
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
 
-          execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}[]"
+          if type.to_s =~ /string|text/
+            execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}[] USING string_to_array(#{quote_column_name(column_name)}, ',')"
+          else
+            execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}[]"
+          end
 
           change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
           change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)


### PR DESCRIPTION
Allow conversion of string/text columns to array so we can do:

``` ruby
# column already exists as string
change_column :data_types, :string_1, :string, :array => true, :default => []
# or as text
change_column :data_types, :text_1, :text, :array => true, :default => []
```

LGTM given by: @nhance
