### PR TITLE
*WIP* Array datatype should return real arrays using #select_one

### DIFF
--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -282,4 +282,21 @@ describe 'Models with array columns' do
       end
     end
   end
+
+  describe '#select_one' do
+    before do
+      Person.create(
+        tags: ["cfabianski", "cedric"],
+        tag_ids: [4, 8, 9]
+      )
+    end
+
+    it 'returns a real array' do
+      query = Person.where(["? = ANY (tags)", "cfabianski"])
+      row   = Person.connection.select_one(query)
+
+      row["tags"].should eq ["cfabianski", "cedric"]
+      row["tag_ids"].should eq [4, 8, 9]
+    end
+  end
 end


### PR DESCRIPTION
_before_

```
query = Person.where(["? = ANY (tags)", "cfabianski"])
Person.connection.select_one(query)
=> {"id"=>"1", "ip"=>nil, "subnet"=>nil, "tag_ids"=>"{4,8,9}", "tags"=>"{cfabianski,cedric}", "biography"=>nil, "lucky_number"=>nil, "num_range"=>nil, "created_at"=>"2013-08-13 06:13:22.441956", "updated_at"=>"2013-08-13 06:13:22.441956"}
```

_after_

```
{"id"=>"1", "ip"=>nil, "subnet"=>nil, "tag_ids"=>[4, 8, 9], "tags"=>["cfabianski", "cedric"], "biography"=>nil, "lucky_number"=>nil, "num_range"=>nil, "created_at"=>"2013-08-13 06:13:22.441956", "updated_at"=>"2013-08-13 06:13:22.441956"}
```

I issued an WIP PR so that I can have some feedback from you.
IMO, it makes a lot of sense to treat the `select_one`, `select_all`, ... using the same mechanisms than the ones used within ActiveRecord.

If you agree I could do the same for example for `hstore`.

WDYT?
