### PR TITLE
Prevent error when calling <association>_ids=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.0 (unreleased)
 
  * Adds Arel predications for `ANY` and `ALL` - Dan McClain
+ * Fixes errors with has_and_belongs_to_many associations - Jacob Swanner
 
 ## 2.1.3
  

--- a/Rakefile
+++ b/Rakefile
@@ -94,6 +94,11 @@ namespace :db do
       t.datetime "updated_at"
     end
 
+    ActiveRecord::Base.connection.create_table :people_tags, force: true do |t|
+      t.integer  "person_id"
+      t.integer  "tag_id"
+    end
+
     ActiveRecord::Base.connection.create_table :tags, force: true do |t|
       t.integer  "person_id"
       t.string   "categories",         array: true

--- a/lib/postgres_ext/arel/visitors/to_sql.rb
+++ b/lib/postgres_ext/arel/visitors/to_sql.rb
@@ -4,7 +4,7 @@ module Arel
   module Visitors
     class ToSql
       def visit_Array o, a
-        column = a.relation.engine.columns.find { |col| col.name == a.name.to_s } if a
+        column = a.relation.engine.connection.columns(a.relation.name).find { |col| col.name == a.name.to_s } if a
         if column && column.respond_to?(:array) && column.array
           quoted o, a
         else

--- a/test/queries/sanity_test.rb
+++ b/test/queries/sanity_test.rb
@@ -21,4 +21,12 @@ describe 'Ensure that we don\'t stomp on Active Record\'s queries' do
       query.must_match /WHERE "tags"\."id" IN \('working'\)/
     end
   end
+
+  describe '#habtm_association_ids=' do
+    it 'properly deletes records through HABTM association method' do
+      person = Person.create(habtm_tag_ids: [Tag.create.id])
+      person.update_attributes(habtm_tag_ids: [])
+      person.habtm_tag_ids.must_be_empty
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ ActiveRecord::Base.establish_connection
 
 class Person < ActiveRecord::Base
   has_many :hm_tags, class_name: 'Tag'
+  has_and_belongs_to_many :habtm_tags, class_name: 'Tag'
 end
 
 class Tag < ActiveRecord::Base


### PR DESCRIPTION
Error raised when creating a delete statement as a result of calling `has_and_belongs_to_many_association_ids=` method.

Error: undefined method `abstract_class?' for Object:Class

Related to dockyard/postgres_ext#102 and perhaps dockyard/postgres_ext#68.
