### PR TITLE
Check if column responds to `array` method before calling it in `add_column_options`

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -282,7 +282,7 @@ module ActiveRecord
       end
 
       def add_column_options!(sql, options)
-        if options[:array] || options[:column].try(:array)
+        if options[:array] || (options[:column].respond_to?(:array) && options[:column].try(:array))
           sql << '[]'
         end
         super


### PR DESCRIPTION
This should resolve #115.
