### PR TITLE
Use schema cache to look up predicate columns

### DIFF
--- a/lib/postgres_ext/active_record/relation/predicate_builder.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder.rb
@@ -29,7 +29,7 @@ module ActiveRecord
             value = value.select(value.klass.arel_table[value.klass.primary_key]) if value.select_values.empty?
             attribute.in(value.arel.ast)
           when Array, ActiveRecord::Associations::CollectionProxy
-            column_definition = engine.connection.columns(table.name).find { |col| col.name == column }
+            column_definition = engine.connection.schema_cache.columns(table.name).find { |col| col.name == column }
 
             if column_definition.respond_to?(:array) && column_definition.array
               attribute.eq(value)


### PR DESCRIPTION
This is required for compatibility with our weird AR hacks, but I thought I'd share it because it also provides a performance boost - your code was introspecting the schema every time it built a predicate.

I realise that this change isn't TDD'd - I hope you're forgive me. If it's any consolation it works really quite well in production.
