### PR TITLE
Avoid errors caused by missing active record files

### DIFF
--- a/lib/postgres_ext/active_record.rb
+++ b/lib/postgres_ext/active_record.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'postgres_ext/active_record/relation'
 require 'postgres_ext/active_record/cte_proxy'
 require 'postgres_ext/active_record/querying'

--- a/lib/postgres_ext/active_record/querying.rb
+++ b/lib/postgres_ext/active_record/querying.rb
@@ -1,5 +1,3 @@
-require 'active_record/querying'
-
 module ActiveRecord::Querying
   delegate :with, :ranked, to: :all
 

--- a/lib/postgres_ext/active_record/relation/predicate_builder.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder.rb
@@ -1,5 +1,3 @@
-require 'active_record/relation/predicate_builder'
-
 module ActiveRecord
   class PredicateBuilder # :nodoc:
     private

--- a/lib/postgres_ext/active_record/relation/query_methods.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods.rb
@@ -1,5 +1,3 @@
-require 'active_record/relation/query_methods'
-
 module ActiveRecord
   module QueryMethods
     class WhereChain


### PR DESCRIPTION
I was encountering this issue:

http://stackoverflow.com/questions/27304441/uninitialized-constant-activerecordquerymethodsrelation-nameerror

And requiring `active_record` fixed the problem.
