### PR TITLE
Fix postgres_ext for rails 4.1

### DIFF
--- a/lib/postgres_ext/active_record/cte_proxy.rb
+++ b/lib/postgres_ext/active_record/cte_proxy.rb
@@ -22,12 +22,8 @@ class CTEProxy
     name
   end
 
-  def relation_delegate_class(*args)
-    @model.relation_delegate_class(*args)
-  end
-
   delegate :column_names, :columns_hash, :model_name, :primary_key, :attribute_alias?,
-    :aggregate_reflections, :instantiate, :type_for_attribute, to: :@model
+    :aggregate_reflections, :instantiate, :type_for_attribute, :relation_delegate_class, to: :@model
 
   private
 


### PR DESCRIPTION
Currently CTEProxy will blow on rails 4.1(.8). This is due to the method 'relation_delegate_class' beeing called upon it.

```
undefined method `relation_delegate_class' for #<CTEProxy:0x007f612e542310>

activerecord (4.1.8) lib/active_record/relation/delegation.rb:112:in `relation_class_for'
activerecord (4.1.8) lib/active_record/relation/delegation.rb:106:in `create'
activerecord (4.1.8) lib/active_record/relation/spawn_methods.rb:67:in `relation_with'
activerecord (4.1.8) lib/active_record/relation/spawn_methods.rb:53:in `except'
activerecord (4.1.8) lib/active_record/relation/calculations.rb:317:in `execute_grouped_calculation'
activerecord (4.1.8) lib/active_record/relation/calculations.rb:225:in `perform_calculation'
activerecord (4.1.8) lib/active_record/relation/calculations.rb:119:in `calculate'
activerecord (4.1.8) lib/active_record/relation/calculations.rb:34:in `count'
```

This PR solves issue #122
