### PR TITLE
Fix WhereChain operators to work on joins

### DIFF
--- a/gemfiles/Gemfile.activerecord-4.2.x
+++ b/gemfiles/Gemfile.activerecord-4.2.x
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec :path => '..'
 
-gem "activerecord", "~> 4.2.0.beta2"
+gem "activerecord", "~> 4.2.0"
 gem "pg", "~> 0.15"
 
 unless ENV['CI'] || RUBY_PLATFORM =~ /java/

--- a/lib/postgres_ext/arel/4.1/visitors.rb
+++ b/lib/postgres_ext/arel/4.1/visitors.rb
@@ -1,1 +1,2 @@
+require 'postgres_ext/arel/4.1/visitors/depth_first'
 require 'postgres_ext/arel/4.1/visitors/postgresql'

--- a/lib/postgres_ext/arel/4.1/visitors/depth_first.rb
+++ b/lib/postgres_ext/arel/4.1/visitors/depth_first.rb
@@ -1,0 +1,9 @@
+require 'arel/visitors/depth_first'
+
+module Arel
+  module Visitors
+    class DepthFirst
+      alias :visit_IPAddr :terminal
+    end
+  end
+end

--- a/lib/postgres_ext/arel/4.1/visitors/postgresql.rb
+++ b/lib/postgres_ext/arel/4.1/visitors/postgresql.rb
@@ -4,13 +4,23 @@ module Arel
   module Visitors
     class PostgreSQL
       private
-      
+
       def visit_Array o, a
         column = a.relation.engine.connection.schema_cache.columns(a.relation.name).find { |col| col.name == a.name.to_s } if a
         if column && column.respond_to?(:array) && column.array
           quoted o, a
         else
           o.empty? ? 'NULL' : o.map { |x| visit x }.join(', ')
+        end
+      end
+
+      def visit_Arel_Nodes_Contains o, a = nil
+        left_column = o.left.relation.engine.columns.find { |col| col.name == o.left.name.to_s }
+        
+        if left_column && (left_column.type == :hstore || (left_column.respond_to?(:array) && left_column.array))
+          "#{visit o.left, a} @> #{visit o.right, o.left}"
+        else
+          "#{visit o.left, a} >> #{visit o.right, o.left}"
         end
       end
       
@@ -22,14 +32,16 @@ module Arel
         "#{visit o.left, a} <<= #{visit o.right, o.left}"
       end
 
-      def visit_Arel_Nodes_Contains o, a = nil
-        left_column = o.left.relation.engine.columns.find { |col| col.name == o.left.name.to_s }
+      def visit_Arel_Nodes_ContainsArray o, a = nil
+        "#{visit o.left, a} @> #{visit o.right, o.left}"
+      end
 
-        if left_column && (left_column.type == :hstore || (left_column.respond_to?(:array) && left_column.array))
-          "#{visit o.left, a} @> #{visit o.right, o.left}"
-        else
-          "#{visit o.left, a} >> #{visit o.right, o.left}"
-        end
+      def visit_Arel_Nodes_ContainsHStore o, a = nil
+        "#{visit o.left, a} @> #{visit o.right, o.left}"
+      end
+
+      def visit_Arel_Nodes_ContainsINet o, a = nil
+        "#{visit o.left, a} >> #{visit o.right, o.left}"
       end
 
       def visit_Arel_Nodes_ContainsEquals o, a = nil

--- a/lib/postgres_ext/arel/4.2/visitors/postgresql.rb
+++ b/lib/postgres_ext/arel/4.2/visitors/postgresql.rb
@@ -4,7 +4,7 @@ module Arel
   module Visitors
     class PostgreSQL
       private
-     
+      
       def visit_Arel_Nodes_ContainedWithin o, collector
         infix_value o, collector, " << " 
       end
@@ -14,15 +14,29 @@ module Arel
       end
 
       def visit_Arel_Nodes_Contains o, collector
-        left_column = o.left.relation.engine.columns.find { |col| col.name == o.left.name.to_s }
+        left_column = o.left.relation.engine.columns.find do |col|
+          col.name == o.left.name.to_s || col.name == o.left.relation.name.to_s
+        end
 
         if left_column && (left_column.type == :hstore || (left_column.respond_to?(:array) && left_column.array))
-          infix_value o, collector, " @> " 
+          infix_value o, collector, " @> "
         else
           infix_value o, collector, " >> " 
         end
       end
 
+      def visit_Arel_Nodes_ContainsINet o, collector
+        infix_value o, collector, " >> " 
+      end
+
+      def visit_Arel_Nodes_ContainsHStore o, collector
+        infix_value o, collector, " @> "
+      end
+      
+      def visit_Arel_Nodes_ContainsArray o, collector
+        infix_value o, collector, " @> "
+      end
+      
       def visit_Arel_Nodes_ContainsEquals o, collector
         infix_value o, collector, " >>= " 
       end

--- a/lib/postgres_ext/arel/nodes/contained_within.rb
+++ b/lib/postgres_ext/arel/nodes/contained_within.rb
@@ -6,15 +6,27 @@ module Arel
     end
 
     class ContainedWithinEquals < Arel::Nodes::Binary
-      def operator; '<<='.to_sym end
+      def operator; :"<<=" end
     end
 
     class Contains < Arel::Nodes::Binary
       def operator; :>> end
     end
+    
+    class ContainsINet < Arel::Nodes::Binary
+      def operator; :>> end
+    end
 
+    class ContainsHStore < Arel::Nodes::Binary
+      def operator; :"@>" end
+    end
+    
+    class ContainsArray < Arel::Nodes::Binary
+      def operator; :"@>" end
+    end
+    
     class ContainsEquals < Arel::Nodes::Binary
-      def operator; '>>='.to_sym end
+      def operator; :">>=" end
     end
   end
 end

--- a/test/queries/array_queries_test.rb
+++ b/test/queries/array_queries_test.rb
@@ -15,9 +15,8 @@ describe 'Array queries' do
 
   describe '.where(joins: { array_column: [] })' do
     it 'returns an array string instead of IN ()' do
-      skip
       query = Person.joins(:hm_tags).where(tags: { categories: ['working'] }).to_sql
-      query.must_match equality_regex
+      query.must_match %r{\"tags\"\.\"categories\" = '\{"?working"?\}'}
     end
   end
 
@@ -32,6 +31,11 @@ describe 'Array queries' do
 
       query.must_match overlap_regex
       query.must_match equality_regex
+    end
+
+    it 'works on joins' do
+      query = Person.joins(:hm_tags).where.overlap(tags: { categories: ['working'] }).to_sql
+      query.must_match %r{\"tags\"\.\"categories\" && '\{"?working"?\}'}
     end
   end
 

--- a/test/queries/contains_test.rb
+++ b/test/queries/contains_test.rb
@@ -41,16 +41,27 @@ describe 'Contains queries' do
       query.to_sql.must_match contains_array_regex
     end
 
-    it 'generates the appropriate where clause for array columns' do
+    it 'generates the appropriate where clause for hstore columns' do
       query = Person.where.contains(data: { nickname: 'Dan' })
       query.to_sql.must_match contains_hstore_regex
     end
 
+    it 'generates the appropriate where clause for hstore columns on joins' do
+      query = Tag.joins(:person).where.contains(people: { data: { nickname: 'Dan' } })
+      query.to_sql.must_match contains_hstore_regex
+    end
+    
     it 'allows chaining' do
       query = Person.where.contains(:tag_ids => [1,2]).where(:tags => ['working']).to_sql
 
       query.must_match contains_array_regex
       query.must_match equality_regex
+    end
+
+    it 'generates the appropriate where clause for array columns on joins' do
+      query = Tag.joins(:person).where.contains(people: { tag_ids: [1,2] }).to_sql
+
+      query.must_match contains_array_regex
     end
   end
 end


### PR DESCRIPTION
Regular ActiveRecord "where" queries can work on joined relations, ie
`Relation.joins(:join).where(join: { has_value: 1 })`, which also
works with the the" WhereChain" `#not` method in ActiveRecord. This adapts
 the `#overlap` and `#contains_*` methods added in this gem to also work on
across join queries.