### PR TITLE
Check for respond_to?(:array) for other DB adaptors.

### DIFF
--- a/lib/postgres_ext/active_record/relation/predicate_builder.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder.rb
@@ -7,7 +7,7 @@ module ActiveRecord
       when Array
         engine = attribute.relation.engine
         column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
-        if column && column.array
+        if column && column.respond_to?(:array) && column.array
           attribute.eq(value)
         else
           values = value.to_a.map {|x| x.is_a?(Base) ? x.id : x}

--- a/lib/postgres_ext/active_record/relation/predicate_builder/array_handler.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder/array_handler.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         def call_with_feature(attribute, value)
           engine = attribute.relation.engine
           column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
-          if column.array
+          if column && column.respond_to?(:array) && column.array
             attribute.eq(value)
           else
             call_without_feature(attribute, value)


### PR DESCRIPTION
when mysql2 is used alongside pg, postgres_ext expects that the column will respond_to? :array, which it doesn’t. See https://github.com/dockyard/postgres_ext/issues/152 for more information.