### PR TITLE
Fix error when creating a join on STI relationship

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,6 +116,8 @@ namespace :db do
       t.string   "categories",         array: true
       t.datetime "created_at"
       t.datetime "updated_at"
+      t.integer  "parent_id"
+      t.string   "type"
     end
 
     puts 'Database migrated'

--- a/test/queries/join_query_test.rb
+++ b/test/queries/join_query_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+describe "Join queries" do
+  describe ".joins(:parent_tag) with STI" do
+    it 'returns a valid sql query' do
+      query = ChildTag.joins(:parent_tag).to_sql
+      query.must_match("SELECT \"tags\".* FROM \"tags\" INNER JOIN \"tags\" \"parent_tags_tags\" ON \"parent_tags_tags\".\"id\" = \"tags\".\"parent_id\" AND \"parent_tags_tags\".\"type\" IN ('ParentTag') WHERE \"tags\".\"type\" IN ('ChildTag')")
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,13 @@ class Tag < ActiveRecord::Base
   belongs_to :person
 end
 
+class ParentTag < Tag
+end
+
+class ChildTag < Tag
+  belongs_to :parent_tag, foreign_key: :parent_id
+end
+
 DatabaseCleaner.strategy = :deletion
 
 class MiniTest::Spec


### PR DESCRIPTION
The `visit_Array` method in the Arel < version 4.1 PostgreSQL visitor
tries to query the schema cache to get the type the column. When querying 
with an STI model using a JOIN statement the Arel node that gets passed
to this method is an `Arel::Nodes::TableAlias` with a name that is not in
the connection's schema cache. Attempting to query the schema cache results
in a database error.

This workaround simply tests if the relation type passed to the
`visit_Array` method is nil or a `Arel::Nodes::TableAlias` and, if so, does
not query the schema cache for the column type.

Closes #154