### PR TITLE
Removed pg_array_parser gem dependency, since it wasn't being used

### DIFF
--- a/postgres_ext.gemspec
+++ b/postgres_ext.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activerecord', '>= 4.0.0'
   gem.add_dependency 'arel', '>= 4.0.1'
-  gem.add_dependency 'pg_array_parser', '~> 0.0.9'
 
   gem.add_development_dependency 'rake', '~> 10.1.0'
   gem.add_development_dependency 'minitest'


### PR DESCRIPTION
be rake test:all
BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-4.0.x' bundle install --quiet
BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-4.0.x' bundle exec rake test
Run options: --seed 38083

# Running tests:

..........................................................

Finished tests in 0.171958s, 337.2917 tests/s, 773.4447 assertions/s.

58 tests, 133 assertions, 0 failures, 0 errors, 0 skips
BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-4.1.x' bundle install --quiet
BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-4.1.x' bundle exec rake test
Run options: --seed 32324

# Running:

..........................................................

Finished in 0.263229s, 220.3405 runs/s, 505.2635 assertions/s.

58 runs, 133 assertions, 0 failures, 0 errors, 0 skips
BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-4.2.x' bundle install --quiet
BUNDLE_GEMFILE='gemfiles/Gemfile.activerecord-4.2.x' bundle exec rake test
Run options: --seed 60207

# Running:

..........................................................

Finished in 0.205119s, 282.7627 runs/s, 648.4041 assertions/s.

58 runs, 133 assertions, 0 failures, 0 errors, 0 skips