### PR TITLE
Fix for rails 5 ActiveRecord::Relation loading order

### DIFF
--- a/lib/postgres_ext/active_record.rb
+++ b/lib/postgres_ext/active_record.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'active_record/relation'
 require 'postgres_ext/active_record/relation'
 require 'postgres_ext/active_record/cte_proxy'
 require 'postgres_ext/active_record/querying'


### PR DESCRIPTION
Rails 5 has a different load order for ActiveRecord::Relation.  Explicitly loading before postgres_ext/active_record/relation keeps things from breaking on Rails 5