### PR TITLE
Fix some issues when looking up aliased tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in postgres_ext.gemspec
 gemspec
 unless ENV['CI']
-  if RUBY_PLATFORM =~ /java/
-    gem 'ruby-debug'
-  else
-    gem 'byebug'
-  end
+  gem 'byebug'
 end
 gem 'fivemat'

--- a/lib/postgres_ext/active_record/relation/predicate_builder.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder.rb
@@ -6,7 +6,12 @@ module ActiveRecord
       case value
       when Array
         engine = attribute.relation.engine
-        column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+        begin
+          column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+        rescue ActiveRecord::StatementInvalid
+          # This occurs if we attempt to lookup a table that doesn't actually exist,
+          #   which can happen when using aliases
+        end
         if column && column.respond_to?(:array) && column.array
           attribute.eq(value)
         else

--- a/lib/postgres_ext/active_record/relation/predicate_builder/array_handler.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder/array_handler.rb
@@ -11,7 +11,12 @@ module ActiveRecord
       included do
         def call_with_feature(attribute, value)
           engine = attribute.relation.engine
-          column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+          begin
+            column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+          rescue ActiveRecord::StatementInvalid
+            # This occurs if we attempt to lookup a table that doesn't actually exist,
+            #   which can happen when using aliases
+          end
           if column && column.respond_to?(:array) && column.array
             attribute.eq(value)
           else

--- a/lib/postgres_ext/active_record/relation/predicate_builder/array_handler.rb
+++ b/lib/postgres_ext/active_record/relation/predicate_builder/array_handler.rb
@@ -10,12 +10,13 @@ module ActiveRecord
 
       included do
         def call_with_feature(attribute, value)
-          engine = attribute.relation.engine
-          begin
-            column = engine.connection.schema_cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
-          rescue ActiveRecord::StatementInvalid
-            # This occurs if we attempt to lookup a table that doesn't actually exist,
-            #   which can happen when using aliases
+          column = case attribute.try(:relation)
+            when Arel::Nodes::TableAlias, NilClass
+            else
+              cache = attribute.relation.engine.connection.schema_cache
+              if cache.table_exists? attribute.relation.name
+                cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+              end
           end
           if column && column.respond_to?(:array) && column.array
             attribute.eq(value)

--- a/lib/postgres_ext/arel/4.1/visitors/postgresql.rb
+++ b/lib/postgres_ext/arel/4.1/visitors/postgresql.rb
@@ -6,16 +6,20 @@ module Arel
       private
 
       def visit_Array o, a
-        column = case a.try(:relation)
-                 when Arel::Nodes::TableAlias, NilClass
-                 # noop Prevent from searching for table alias name in schema cache
-                 # which won't exist for aliased table when used with Single Table
-                 # Inheritance. see dockyard/postgres_ext#154
-                 else
-                   a.relation.engine.connection.schema_cache.columns(a.relation.name)
-                     .find { |col| col.name == a.name.to_s }
-                 end
-        
+        begin
+          column = case a.try(:relation)
+                   when Arel::Nodes::TableAlias, NilClass
+                   # noop Prevent from searching for table alias name in schema cache
+                   # which won't exist for aliased table when used with Single Table
+                   # Inheritance. see dockyard/postgres_ext#154
+                   else
+                     a.relation.engine.connection.schema_cache.columns(a.relation.name)
+                       .find { |col| col.name == a.name.to_s }
+                   end
+        rescue ActiveRecord::StatementInvalid
+          # This occurs if we attempt to lookup a table that doesn't actually exist,
+          #   which can happen when using aliases
+        end
         if column && column.respond_to?(:array) && column.array
           quoted o, a
         else
@@ -25,14 +29,14 @@ module Arel
 
       def visit_Arel_Nodes_Contains o, a = nil
         left_column = o.left.relation.engine.columns.find { |col| col.name == o.left.name.to_s }
-        
+
         if left_column && (left_column.type == :hstore || (left_column.respond_to?(:array) && left_column.array))
           "#{visit o.left, a} @> #{visit o.right, o.left}"
         else
           "#{visit o.left, a} >> #{visit o.right, o.left}"
         end
       end
-      
+
       def visit_Arel_Nodes_ContainedWithin o, a = nil
         "#{visit o.left, a} << #{visit o.right, o.left}"
       end

--- a/lib/postgres_ext/arel/4.1/visitors/postgresql.rb
+++ b/lib/postgres_ext/arel/4.1/visitors/postgresql.rb
@@ -6,20 +6,18 @@ module Arel
       private
 
       def visit_Array o, a
-        begin
-          column = case a.try(:relation)
-                   when Arel::Nodes::TableAlias, NilClass
-                   # noop Prevent from searching for table alias name in schema cache
-                   # which won't exist for aliased table when used with Single Table
-                   # Inheritance. see dockyard/postgres_ext#154
-                   else
-                     a.relation.engine.connection.schema_cache.columns(a.relation.name)
-                       .find { |col| col.name == a.name.to_s }
-                   end
-        rescue ActiveRecord::StatementInvalid
-          # This occurs if we attempt to lookup a table that doesn't actually exist,
-          #   which can happen when using aliases
-        end
+        column = case a.try(:relation)
+                 when Arel::Nodes::TableAlias, NilClass
+                 # noop Prevent from searching for table alias name in schema cache
+                 # which won't exist for aliased table when used with Single Table
+                 # Inheritance. see dockyard/postgres_ext#154
+                 else
+                  cache = a.relation.engine.connection.schema_cache
+                  if cache.table_exists? a.relation.name
+                    cache.columns(a.relation.name).find { |col| col.name == a.name.to_s }
+                  end
+                 end
+
         if column && column.respond_to?(:array) && column.array
           quoted o, a
         else

--- a/test/queries/alias_test.rb
+++ b/test/queries/alias_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+describe 'Joining with an alias' do
+  it "Works properly" do
+    ChildTag.includes(:parent_tag).references(:parent_tag)
+      .where("parent_tags_tags.id" => [2,3,4]).to_sql.must_match /"parent_tags_tags"."id" IN \(2, 3, 4\)/
+  end
+end


### PR DESCRIPTION
The lookup for whether or not a column is an array fails in certain cases when using aliased tables.  This fixes that issues.