### PR TITLE
Preserve RECURSIVE flag of CTE relations when they are merged.

### DIFF
--- a/lib/postgres_ext/active_record/relation/merger.rb
+++ b/lib/postgres_ext/active_record/relation/merger.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   class Relation
     class Merger # :nodoc:
       def normal_values
-        NORMAL_VALUES + [:with]
+        NORMAL_VALUES + [:with, :recursive]
       end
     end
   end

--- a/lib/postgres_ext/active_record/relation/query_methods.rb
+++ b/lib/postgres_ext/active_record/relation/query_methods.rb
@@ -201,6 +201,11 @@ module ActiveRecord
       self
     end
 
+    def recursive!(value)
+      self.recursive_value = value
+      self
+    end
+
     def build_arel_with_extensions
       arel = build_arel_without_extensions
 

--- a/test/queries/common_table_expression_test.rb
+++ b/test/queries/common_table_expression_test.rb
@@ -22,6 +22,14 @@ describe 'Common Table Expression queries' do
       query.to_sql.must_match(/WITH RECURSIVE "lucky_number_seven" AS \(SELECT "people".* FROM "people"(\s+)WHERE "people"."lucky_number" = 7\) SELECT "people".* FROM "people" JOIN lucky_number_seven ON lucky_number_seven.id = people.id/)
     end
 
+    it 'preserves recursive expression during merges' do
+      merge_recursive_in   = Tag.all.merge(Tag.recursive)
+      merge_recursive_in.to_sql.must_match(/WITH RECURSIVE "recursive" AS \(SELECT "tags".* FROM "tags"(\s+)WHERE "tags"."tag" = 'tag'\) SELECT "tags".* FROM "tags"/)
+
+      merge_into_recursive = Tag.recursive.merge(Tag.all)
+      merge_into_recursive.to_sql.must_match(/WITH RECURSIVE "recursive" AS \(SELECT "tags".* FROM "tags"(\s+)WHERE "tags"."tag" = 'tag'\) SELECT "tags".* FROM "tags"/)
+    end
+
     it 'accepts Arel::SelectMangers' do
       arel_table = Arel::Table.new 'test'
       arel_manager = arel_table.project arel_table[:foo]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,8 @@ end
 
 class Tag < ActiveRecord::Base
   belongs_to :person
+
+  scope :recursive, -> { with.recursive(recursive: Tag.where(tag: 'tag')) }
 end
 
 class ParentTag < Tag


### PR DESCRIPTION
This pull request fixes what I think to be a bug in the handling of recursive CTEs during merges.

Queries like the following:
Tag.all.merge(Tag.with.recursive(recursive: Tag.where(tag: 'tag')))
Tag.with.recursive(recursive: Tag.where(tag: 'tag')).merge(Tag.all)

would both be expected to produce a query like:
WITH RECURSIVE "recursive"
   AS ( SELECT "tags".*
          FROM "tags"
         WHERE "tags"."tag" = 'tag')
SELECT "tags".*
  FROM "tags"

but currently only the second one would. The first would lose the recursive flag
during merge and result in:
WITH "recursive"
   AS ( SELECT "tags".*
          FROM "tags"
         WHERE "tags"."tag" = 'tag')
SELECT "tags".*
  FROM "tags"

Adding :recursive to ActiveRecord::Relation::Merger#normal_values
and a #recursive! method to ActiveRecord::QueryMethods the expected behavior
regardless of the direction of the merge.

<!--
Thank you for contributing!

Here are a few things that will increase the chance that your pull request will get accepted:
 - Write tests, preferably in a test driven style.
 - Add documentation for the changes you made.
 - Follow our styleguide: https://github.com/dockyard/styleguides
-->

<!-- If this pull request addresses an issue please provide the issue number here -->
Closes # .

## Changes proposed in this pull request
<!-- Please describe here what this pull request changes -->
