### PR TITLE
Constrain AR to 4

### DIFF
--- a/postgres_ext.gemspec
+++ b/postgres_ext.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PostgresExt::VERSION
 
-  gem.add_dependency 'activerecord', '>= 4.0.0'
+  gem.add_dependency 'activerecord', '~> 4.0'
   gem.add_dependency 'arel', '>= 4.0.1'
   gem.add_dependency 'pg_array_parser', '~> 0.0.9'
 


### PR DESCRIPTION
Seems to not be compatible with AR 5? Or, more specifically, not compatible with arel 7?

In AR 5 when I call `group_by` on a relation, I get an `ArgumentError`. Removing `postgres_ext` from my Gemfile seems to fix the problem.

```
gems/arel-7.1.4/lib/arel/visitors/reduce.rb:12:in `visit'
gems/postgres_ext-3.0.0/lib/postgres_ext/arel/4.1/visitors/postgresql.rb:22:in `block in visit_Array'
gems/postgres_ext-3.0.0/lib/postgres_ext/arel/4.1/visitors/postgresql.rb:22:in `map'
gems/postgres_ext-3.0.0/lib/postgres_ext/arel/4.1/visitors/postgresql.rb:22:in `visit_Array'
gems/arel-7.1.4/lib/arel/visitors/reduce.rb:13:in `visit'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:621:in `visit_Arel_Nodes_In'
gems/activerecord-5.0.1/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:13:in `visit_Arel_Nodes_In'
gems/arel-7.1.4/lib/arel/visitors/reduce.rb:13:in `visit'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:823:in `block in inject_join'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:821:in `each'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:821:in `each_with_index'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:821:in `each'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:821:in `inject'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:821:in `inject_join'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:637:in `visit_Arel_Nodes_And'
gems/arel-7.1.4/lib/arel/visitors/reduce.rb:13:in `visit'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:269:in `block in collect_nodes_for'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:268:in `each'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:268:in `each_with_index'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:268:in `collect_nodes_for'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:253:in `visit_Arel_Nodes_SelectCore'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:216:in `block in visit_Arel_Nodes_SelectStatement'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:215:in `each'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:215:in `inject'
gems/arel-7.1.4/lib/arel/visitors/to_sql.rb:215:in `visit_Arel_Nodes_SelectStatement'
gems/arel-7.1.4/lib/arel/visitors/reduce.rb:13:in `visit'
gems/arel-7.1.4/lib/arel/visitors/reduce.rb:7:in `accept'
gems/activerecord-5.0.1/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb:8:in `accept'
gems/activerecord-5.0.1/lib/active_record/connection_adapters/abstract/database_stat 
```