### PR TITLE
Suggest ActiveRecordExtended as an alternative to Rails > 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # This Gem is No Longer Maintained
 
-It still works and may be useful to you for Rails versions < 5, but will not be updated to be compatible with Rails version > 5. 
+It still works and may be useful to you for Rails versions < 5, but will not be updated to be compatible with Rails version > 5.
+
+If you need support for Rails > 5 consider using [ActiveRecordExtended](https://github.com/georgekaraszi/ActiveRecordExtended)
 
 # PostgresExt
 


### PR DESCRIPTION
Suggest ActiveRecordExtended gem as an alternative to projects running Rails > 5 as there is no plan to update this gem to be compatible with Rails > 5.